### PR TITLE
wait after deleting targets with same name but different ARN

### DIFF
--- a/src/main/scala/com/gu/inspectorlambda/chiefinspector/ChiefInspector.scala
+++ b/src/main/scala/com/gu/inspectorlambda/chiefinspector/ChiefInspector.scala
@@ -44,7 +44,10 @@ object ChiefInspector extends StrictLogging {
     val assessmentTemplates = matchingInstanceSets.map { case (tagCombo, _) =>
       val name = constructName(tagCombo)
       val resourceGroupArn: String = inspector.getResourceGroup(name) getOrElse inspector.createResourceGroup(name)
-      val assessmentTargetArn = inspector.getAssessmentTarget(name, resourceGroupArn) getOrElse inspector.createAssessmentTarget(name, resourceGroupArn)
+      val assessmentTargetArn = inspector.getAssessmentTarget(name, resourceGroupArn) getOrElse {
+        Thread.sleep(5000) // allow deletion of old asessment targets to take effect
+        inspector.createAssessmentTarget(name, resourceGroupArn)
+      }
       val assessmentTemplateArn = inspector.getAssessmentTemplate(name, assessmentTargetArn) getOrElse inspector.createAssessmentTemplate(name, assessmentTargetArn)
       (tagCombo, assessmentTemplateArn)
     }


### PR DESCRIPTION
The code which tries to find an existing set of assessment targets, has the functionality to delete targets which have the same name but a different ARN:

```scala
def getAssessmentTarget(name: String, arn: String): Option[String] = {
    // ... <SNIP> ...

    // delete if arn is not correct
    matchingAssessmentTargets
      .filter(!_.getResourceGroupArn.equals(arn))
      .foreach(assessmentTarget => {
        logger.info(s"Deleting ${assessmentTarget.getArn}")
        val deleteAssessmentTargetRequest = new DeleteAssessmentTargetRequest()
          .withAssessmentTargetArn(assessmentTarget.getArn)
        client.deleteAssessmentTarget(deleteAssessmentTargetRequest)
      })
```
If it then finds that there are none left with the correct ARN, it will try to make one (`CheifInspector.scala:47`):

```
val assessmentTargetArn = inspector.getAssessmentTarget(name, resourceGroupArn) getOrElse inspector.createAssessmentTarget(name, resourceGroupArn)
```

However, if the first code block initiated a deletion, then it may not have finished by the time the second code block attempts to create a new target with the same name, resulting in an exception.

```
[error] (run-main-b) com.amazonaws.services.inspector.model.InvalidInputException: Create assessmentTarget - Name already exists; Name: AWSInspection--ophan--tracker--PROD ParentOwner: 021353022223 (Service: AmazonInspector; Status Code: 400; Error Code: InvalidInputException; Request ID: dbe90419-4d4a-11e8-b404-71cc2b29381d)
[error] com.amazonaws.services.inspector.model.InvalidInputException: Create assessmentTarget - Name already exists; Name: AWSInspection--ophan--tracker--PROD ParentOwner: 021353022223 (Service: AmazonInspector; Status Code: 400; Error Code: InvalidInputException; Request ID: dbe90419-4d4a-11e8-b404-71cc2b29381d)
```

This change forces it to wait for an appropriate amount of time before trying to create the new target.