### PR TITLE
update sbt

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.6.0

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.6.0"


### PR DESCRIPTION
## What does this change?

Updates SBT ahead of snyk integration
Previously, we were using a version of SBT from so long ago that dependencyTree wasn't included, which causes snyk to fail. Now it's been included

## How to test

Run `sbt  dependencyTree`
